### PR TITLE
Only respecting redirection if passed in the request vars, then overriding. This supports other frontend login forms like Theme My Login.

### DIFF
--- a/pmpro-member-homepages.php
+++ b/pmpro-member-homepages.php
@@ -26,19 +26,19 @@ add_action( 'init', 'pmpromh_load_plugin_text_domain' );
 */
 function pmpromh_login_redirect( $redirect_to, $request, $user ) {
 
-	// If already redirecting, respect that URL.
-	if ( ! empty( $redirect_to ) ) {
-		return $redirect_to;
+	// Set the redirection if a redirect_to is passed in the URL.
+	if ( ! empty( $_REQUEST['redirect_to'] ) ) {
+		$redirect_to = $_REQUEST['redirect_to'];
 	}
 
 	//check level
-	if(!empty( $user ) && !empty( $user->ID ) && function_exists( 'pmpro_getMembershipLevelForUser' ) ) {
+	if ( ! empty( $user ) && ! empty( $user->ID ) && function_exists( 'pmpro_getMembershipLevelForUser' ) ) {
 		$level = pmpro_getMembershipLevelForUser( $user->ID );
 	
-		if( !empty( $level ) && isset( $level->id ) ) {
+		if ( ! empty( $level ) && isset( $level->id ) ) {
 			$member_homepage_id = pmpromh_getHomepageForLevel( $level->id );
 
-			if( ! empty( $member_homepage_id ) && ! is_page( $member_homepage_id ) ) {
+			if ( ! empty( $member_homepage_id ) && ! is_page( $member_homepage_id ) ) {
 				$redirect_to = get_permalink( $member_homepage_id );
 			}
 		}


### PR DESCRIPTION
The last update in version 0.2 added respect for a redirect_to variable in the login_redirect WP filter. 

This update will now do the following:
- First, respect the $_REQUEST redirect_to value.
- Second, always set the redirection to the Member Homepage, regardless of whether the filter receives a $redirect_to variable.
- Third, if we haven't updated the $redirect_to var, return that var. This is the case where you may be using Theme My Login and is always setting a redirect_to attribute in their front-end form. If the logging in user doesn't have a member homepage, send them where TML says to send them.
