### PR TITLE
Skip default redirects

### DIFF
--- a/pmpro-member-homepages.php
+++ b/pmpro-member-homepages.php
@@ -34,6 +34,21 @@ function pmpromh_login_redirect( $redirect_to, $request, $user ) {
 		if ( ! empty( $level_id ) ) {
 			$member_homepage_id = pmpromh_getHomepageForLevel( $level_id );
 			$ignore_redirect_to = pmpromh_ignore_redirect_to( $level_id );
+
+			// Check if we're redirecting to a default login redirect path, if so, let's skip this since we want to redirect elsewhere.
+			if ( ! $ignore_redirect_to ) {
+				$skip_redirects = apply_filters( 'pmpromh_skip_redirect_urls',
+					array(
+						pmpro_url( 'login' ),
+						site_url( '/wp-admin/' )
+					)
+				);
+
+				// Trying to redirect_to a default URL, let's skip this and let our plugin handle the redirect.
+				if ( in_array( $redirect_to, $skip_redirects ) ) {
+					$redirect_to = false;
+				}
+			}
 			// Member has a member homepage, override the redirect_to if level set to ignore other redirects.
 			if ( ! empty( $member_homepage_id ) && ! is_page( $member_homepage_id ) && ( empty( $redirect_to ) || ! empty( $ignore_redirect_to ) ) ) {
 				$redirect_to = get_permalink( $member_homepage_id );
@@ -43,7 +58,7 @@ function pmpromh_login_redirect( $redirect_to, $request, $user ) {
 
 	return $redirect_to;
 }
-add_filter('login_redirect', 'pmpromh_login_redirect', 9, 3);
+add_filter( 'login_redirect', 'pmpromh_login_redirect', 9, 3 );
 
 /*
 	Function to redirect member to their membership level's homepage when 


### PR DESCRIPTION
* ENHANCEMENT: Added functionality to override the default redirect_tos that are set by WordPress such as the PMPro login URL or the admin dashboard.

It seems that the $redirect_to value is always being set even if one isn't passed through specifically on the login page (either PMPro's frontend login or the default WordPress dashboard).

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?
